### PR TITLE
Update config to use the right module

### DIFF
--- a/etc/modules/pickle-retention-file-scheduler.cfg
+++ b/etc/modules/pickle-retention-file-scheduler.cfg
@@ -3,6 +3,6 @@
 # Retention file to keep state between process restarts.
 define module {
     module_name     pickle-retention-file
-    module_type     pickle_retention_file_generic
+    module_type     pickle_retention_file
     path            /var/lib/shinken/retention.dat
 }


### PR DESCRIPTION
Ok, I don't get it.
Was this config file correct ? And what is this module exactly ?
What is the real difference with mod-pickle-retention-file-generic ?
If I read well the code, they are identical...
If yes, I think we should delete it...
